### PR TITLE
Documentation - Padding at the bottom of the box 

### DIFF
--- a/src/scripts/main/public/styles/documentation.css
+++ b/src/scripts/main/public/styles/documentation.css
@@ -32,6 +32,8 @@ header h1 {
     display: flex;
     flex-direction: column;
     align-items: center;
+    height: fit-content;
+    padding-bottom: 5%;
 }
 
 .controls-wrapper {


### PR DESCRIPTION
## Documentation - Pull Request

**Description**
Small fix to solve the issue of the outer yellow box of the documentation page not scaling correctly on smaller devices, and having larger than needed padding at the bottom. Changed the styling of the outer box to fit-content and added 5% padding for relative scaling.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

**Screenshots**

**Previous:**
![image](https://github.com/cse110-sp24-group8/cse110-sp24-group8/assets/122563165/41e6cb58-a480-46eb-819c-89d4169dd96b)
![image](https://github.com/cse110-sp24-group8/cse110-sp24-group8/assets/122563165/4c5b4e40-f163-4f1d-bfd7-9b4ba4e88012)

**New**:

![image](https://github.com/cse110-sp24-group8/cse110-sp24-group8/assets/122563165/f3996d25-a03d-4360-a5cb-e1c8a84cfa83)
![image](https://github.com/cse110-sp24-group8/cse110-sp24-group8/assets/122563165/a5f72a87-5092-4339-8f37-4f53c5d49bf2)

**Additional context**
@nicholas-ngyn @cheung-arthur Would request if you guys can scale the inside white area (Markdown input) to an appropriate percentage of the screen, which will allow the outer box to take up the whole screen instead of just a part of it


